### PR TITLE
CompatHelper: add new compat entry for "Interpolations" at version "0.12"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 HCIToolbox = "0.1,0.2,0.3"
 ImageTransformations = "0.8"
+Interpolations = "0.12"
 NMF = "0.4"
 ProgressLogging = "0.1"
 julia = "1.3"


### PR DESCRIPTION
This pull request sets the compat entry for the `Interpolations` package to `0.12`.

This is a brand new compat entry. Previously, you did not have a compat entry for the `Interpolations` package.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request. Note: Consider tagging a patch release immediately after merging this PR, as downstream packages may depend on this for tests to pass.